### PR TITLE
Convert implementation from pointers to vectors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CMakePackageConfigHelpers)
 
 project(H264Encoder
   LANGUAGES C CXX
-  VERSION 2.1.1)
+  VERSION 2.0.0)
 
 add_library(H264Encoder STATIC
   src/encoder.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CMakePackageConfigHelpers)
 
 project(H264Encoder
   LANGUAGES C CXX
-  VERSION 1.1.1)
+  VERSION 2.1.1)
 
 add_library(H264Encoder STATIC
   src/encoder.cpp)

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -1,6 +1,8 @@
 #include "encoder.hpp"
 
 #include <iostream>
+
+extern "C" {
 #include <x264.h>
 
 #include <libavcodec/avcodec.h>
@@ -8,6 +10,7 @@
 #include <libavformat/avio.h>
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
+}
 
 namespace h264encoder {
 

--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -19,7 +19,7 @@ private:
 	x264_t* enc;
 	x264_param_t prms;
 	x264_picture_t pic_in, pic_out;
-	x264_nal_t* nals; // used everywhere in the code
+	x264_nal_t* nals;
 
 	struct SwsContext* sws;
 	AVFrame pic_raw; /* used for our "raw" input container */

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -3,17 +3,8 @@
 #define ENCODER_HPP_
 
 #include <memory>
+#include <vector>
 #include <stdint.h>
-
-extern "C" {
-#include <x264.h>
-
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-#include <libavformat/avio.h>
-#include <libavutil/imgutils.h>
-#include <libswscale/swscale.h>
-}
 
 namespace h264encoder {
 
@@ -32,7 +23,7 @@ typedef struct x264_nal_t_simple {
 
 class Encoder {
 public:
-	x264_nal_t_simple* nals;
+	std::vector<x264_nal_t_simple> nals;
 	int num_nals;
 	Encoder(){};
 	Encoder(int, int, int, int, float);

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -3,8 +3,8 @@
 #define ENCODER_HPP_
 
 #include <memory>
-#include <vector>
 #include <stdint.h>
+#include <vector>
 
 namespace h264encoder {
 

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -24,7 +24,6 @@ typedef struct x264_nal_t_simple {
 class Encoder {
 public:
 	std::vector<x264_nal_t_simple> nals;
-	int num_nals;
 	Encoder(){};
 	Encoder(int, int, int, int, float);
 	int encode(unsigned char*);


### PR DESCRIPTION
Instead of using arrays with number of elements for storing the nals, I've changed it to vectors, and I've also moved the problematic imports from the header to the implementation